### PR TITLE
🔧 Add main and types to package.json sort

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -56,11 +56,14 @@ export function json(options = {}) {
 
 							`type`,
 							`engines`, // Often used for ESM, so relates to `type`
+							`engineStrict`,
 
 							// Export fields
 							`bin`,
 							`directories`,
 							`files`,
+							`main`,
+							`types`,
 							`exports`,
 							// End export fields
 
@@ -72,7 +75,6 @@ export function json(options = {}) {
 							// End tool-specific
 
 							// Dependency related, specific order
-							`engineStrict`,
 							`overrides`, // Overrides before dependencies to emphasize their existence
 							`optionalDependencies`,
 							`peerDependencies`,


### PR DESCRIPTION
Adds `main` and `types` to `package.json` sort order. Changes `engineStrict` location. Run `--fix` when upgrading.

+semver:minor