### PR TITLE
🚨 Suppress @html-eslint/attrs-newline

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -14,6 +14,7 @@ export const html = tseslint.config({
 	},
 	rules: {
 		...htmlPlugin.configs[`flat/recommended`].rules,
+		"@html-eslint/attrs-newline": `off`, // Formatting
 		"@html-eslint/id-naming-convention": [`error`, `kebab-case`],
 		"@html-eslint/indent": `off`, // Formatting
 		"@html-eslint/no-abstract-roles": `error`, // Accessibility


### PR DESCRIPTION
Suppresses `@html-eslint/attrs-newline` which prettier handles.